### PR TITLE
 Remove osx newline symbols in cleanImport() function

### DIFF
--- a/commands/compile.js
+++ b/commands/compile.js
@@ -218,6 +218,8 @@ function loadInImportsForEtherscan(input,dependencies,broughtInDep){
 
 function cleanImport(thisLine){
   thisLine = thisLine.split("import").join("")
+  thisLine = thisLine.split("\r").join("")
+  thisLine = thisLine.split("\n").join("")
   thisLine = thisLine.split("\"").join("")
   thisLine = thisLine.split("'").join("")
   thisLine = thisLine.split(";").join("")

--- a/commands/compile.js
+++ b/commands/compile.js
@@ -219,7 +219,6 @@ function loadInImportsForEtherscan(input,dependencies,broughtInDep){
 function cleanImport(thisLine){
   thisLine = thisLine.split("import").join("")
   thisLine = thisLine.split("\r").join("")
-  thisLine = thisLine.split("\n").join("")
   thisLine = thisLine.split("\"").join("")
   thisLine = thisLine.split("'").join("")
   thisLine = thisLine.split(";").join("")


### PR DESCRIPTION
This fix allows compiling smart contracts on osx, before it was throwing an error `ERROR, failed to load in dependency for [contract_name]` even if the contract_name was in dependencies lists. All because of `\r` symbol