### PR TITLE
Clevis does not return the correct address when using private key

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "scrypt": "^6.0.3",
     "sha3": "^1.2.2",
     "solc": "^0.5.9",
-    "truffle-hdwallet-provider": "0.0.6",
+    "truffle-hdwallet-provider": "1.0.8",
     "typedarray-to-buffer": "^3.1.5",
     "web3": "^1.0.0-beta.33",
     "winston": "^3.1.0"


### PR DESCRIPTION
Clevis does not return the correct address when `USE_INFURA=true` and the private key. The problem originates in the current version of the `truffle-hdwallet-provider`. Updating its version solve the problem (see this [post](https://ethereum.stackexchange.com/a/70478))